### PR TITLE
Add `*.swp` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+*.swp
 .DS_Store


### PR DESCRIPTION
Vim swap files (*.swp) are not needed in version control.