### PR TITLE
Pin libigl to 2.5.1 for Genesis compatibility

### DIFF
--- a/openarm_genesis/environment.yaml
+++ b/openarm_genesis/environment.yaml
@@ -15,3 +15,4 @@ dependencies:
       - taichi==1.7.3
       - torch==2.6.0
       - torchvision==0.21.0
+      - libigl==2.5.1


### PR DESCRIPTION
Genesis throws an error when using the latest libigl (2.6.1):
<pre>  File "/home/a/miniconda3/envs/openarm_genesis/lib/python3.11/site-packages/genesis/engine/entities/rigid_entity/rigid_geom.py", line 224, in _compute_sd
    sd, _, _ = igl.signed_distance(query_points, self._sdf_verts, self._sdf_faces)
    ^^^^^^^^
ValueError: too many values to unpack (expected 3)
[Genesis] [23:11:50] [INFO] 💤 Exiting Genesis and caching compiled kernels... </pre>
This is due to a change in igl.signed_distance()'s return signature in v2.6+.
Downgrading to libigl==2.5.1 resolves the issue.